### PR TITLE
Rtp error patch

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,8 @@ func main() {
 
 		packet := &rtp.Packet{}
 		if err = packet.Unmarshal(inboundRTPPacket[:n]); err != nil {
-			panic(err)
+			fmt.Printf("Error unmarshaling RTP packet %s\n", err)
+			// panic(err)
 		}
 
 		if packet.Header.PayloadType == 96 {

--- a/main.go
+++ b/main.go
@@ -100,8 +100,10 @@ func main() {
 
 		packet := &rtp.Packet{}
 		if err = packet.Unmarshal(inboundRTPPacket[:n]); err != nil {
-			fmt.Printf("Error unmarshaling RTP packet %s\n", err)
-			// panic(err)
+			//It has been found that the windows version of OBS sends us some malformed packets
+			//It does not effect the stream so we will disable any output here
+			//fmt.Printf("Error unmarshaling RTP packet %s\n", err)
+			
 		}
 
 		if packet.Header.PayloadType == 96 {


### PR DESCRIPTION
It has been found that OBS on Windows sends us some malformed packets so we will remove output for unmarshaling errors since it does not effect the stream. 