### PR TITLE
Use local directory for building docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+README.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM golang:1.14
+FROM golang:1.14 as builder
 
 WORKDIR /go/src/app
+COPY . .
 ENV GO111MODULE=on
-RUN go get github.com/GRVYDEV/lightspeed-webrtc
+RUN go mod download
+RUN go build -o lightspeed-webrtc .
+
+
+FROM debian:buster-slim
+COPY --from=builder /go/src/app/lightspeed-webrtc /usr/local/bin/
+EXPOSE 8080
 
 #CMD ["lightspeed-webrtc --addr=XXX.XXX.XXX.XXX", "run"]
 # defaults to localhost:8080, then up to docker compose to bind ports


### PR DESCRIPTION
(Also use multistage build to make a smaller image)

Closes #18 