### PR TITLE
Simpler and more efficient cleanConnections

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"flag"
 
@@ -163,36 +162,18 @@ func createWebrtcApi() *webrtc.API {
 	return webrtc.NewAPI(webrtc.WithMediaEngine(m), webrtc.WithInterceptorRegistry(i), webrtc.WithSettingEngine(s))
 }
 
-func cleanConnections() {
+func cleanConnection(peerConnection *webrtc.PeerConnection) {
 	listLock.Lock()
-	defer func() {
-		listLock.Unlock()
-	}()
-	attemptClean := func() (tryAgain bool) {
-		for i := range peerConnections {
-			if peerConnections[i].peerConnection.ConnectionState() == webrtc.PeerConnectionStateClosed {
-				peerConnections = append(peerConnections[:i], peerConnections[i+1:]...)
-				return true // We modified the slice, start from the beginning
-			}
-		}
-		return
-	}
+	defer listLock.Unlock()
 
-	for cleanAttempt := 0; ; cleanAttempt++ {
-		if cleanAttempt == 25 {
-			// Release the lock and attempt a sync in 3 seconds. We might be blocking a RemoveTrack or AddTrack
-			go func() {
-				time.Sleep(time.Second * 3)
-				cleanConnections()
-			}()
+	for i := 0; i < len(peerConnections); {
+		if peerConnection == peerConnections[i].peerConnection {
+			peerConnections[i] = peerConnections[len(peerConnections)-1]
+			peerConnections[len(peerConnections)-1] = peerConnectionState{}
+			peerConnections = peerConnections[:len(peerConnections)-1]
 			return
 		}
-
-		if !attemptClean() {
-			break
-		}
 	}
-
 }
 
 // Handle incoming websockets
@@ -284,7 +265,7 @@ func websocketHandler(w http.ResponseWriter, r *http.Request) {
 				log.Print(err)
 			}
 		case webrtc.PeerConnectionStateClosed:
-			cleanConnections()
+			cleanConnection(peerConnection)
 
 		}
 	})

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func cleanConnection(peerConnection *webrtc.PeerConnection) {
 	listLock.Lock()
 	defer listLock.Unlock()
 
-	for i := 0; i < len(peerConnections); {
+	for i := range peerConnections {
 		if peerConnection == peerConnections[i].peerConnection {
 			peerConnections[i] = peerConnections[len(peerConnections)-1]
 			peerConnections[len(peerConnections)-1] = peerConnectionState{}


### PR DESCRIPTION
I was glancing through the code and was interested by this function.

I think it can be simplified in this way -- even if the connection is blocking on a Remove/AddTrack at the instant, the peer connection still signaled it closed so I think it'd be appropriate to boot it out of the list instantly? Which as far I as I see is only used for telemetry at the moment. (A [prometheus](https://prometheus.io/) counter might actually be what you want 🙂 )

Also, I noticed you were using order-preserving delete, which required reallocating, or at least copying, the entire list if you removed the first element. But you don't need to preserve order, so you can do a simple cheap swap instead.