### PR TITLE
Statically link binary and remove dependency on debian:buster-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@ WORKDIR /go/src/app
 COPY . .
 ENV GO111MODULE=on
 RUN go mod download
-RUN go build -o lightspeed-webrtc .
+RUN go build -ldflags "-linkmode external -extldflags -static" -o lightspeed-webrtc .
 
 
-FROM debian:buster-slim
+FROM scratch
 COPY --from=builder /go/src/app/lightspeed-webrtc /usr/local/bin/
 EXPOSE 8080
 


### PR DESCRIPTION
Corresponding to https://github.com/GRVYDEV/Lightspeed-ingest/pull/35 statically linking the binary and removing the dependency on buster-slim makes the image smaller.