### PR TITLE
Add support for WSS:// with arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ go build
 | `--ports`  | A valid UDP port range | `20000-20500` | This sets the UDP ports that WebRTC will use to connect with the client |
 | `--ws-port` | A valid port number | `8080` | This is the port on which the websocket will be hosted. If you change this value make sure that is reflected in the URL used by the react client |
 | `--rtp-port` | A valid port number | `65535` | This is the port on which the WebRTC service will listen for RTP packets. Ensure this is the same port that Lightspeed Ingest is negotiating with the client |
+| `--ssl-cert` | A valid ssl cert path | | This is the ssl cert that the websocket server will use. If omitted, the websocket will not be served over ssl. |
+| `--ssl-key` | A valid port number | | This is the ssl private key that the websocket server will use. If omitted, the websocket will not be served over ssl. |
 
 
 

--- a/main.go
+++ b/main.go
@@ -26,6 +26,8 @@ var (
 	wsPort   = flag.Int("ws-port", 8080, "Port for websocket")
 	rtpPort  = flag.Int("rtp-port", 65535, "Port for RTP")
 	ports    = flag.String("ports", "20000-20500", "Port range for webrtc")
+	sslCert  = flag.String("ssl-cert", "", "Ssl cert for websocket(optional)")
+	sslKey   = flag.String("ssl-key", "", "Ssl key for websocket (optional)")
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },
 	}
@@ -73,7 +75,12 @@ func main() {
 	go func() {
 		http.HandleFunc("/websocket", websocketHandler)
 
-		log.Fatal(http.ListenAndServe(*addr+":"+strconv.Itoa(*wsPort), nil))
+		wsAddr := *addr+":"+strconv.Itoa(*wsPort)
+		if *sslCert != "" && *sslKey != "" {
+			log.Fatal(http.ListenAndServeTLS(wsAddr, *sslCert, *sslKey, nil))
+		} else {
+			log.Fatal(http.ListenAndServe(wsAddr, nil))
+		}
 	}()
 
 	inboundRTPPacket := make([]byte, 4096) // UDP MTU

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 	wsPort   = flag.Int("ws-port", 8080, "Port for websocket")
 	rtpPort  = flag.Int("rtp-port", 65535, "Port for RTP")
 	ports    = flag.String("ports", "20000-20500", "Port range for webrtc")
-	sslCert  = flag.String("ssl-cert", "", "Ssl cert for websocket(optional)")
+	sslCert  = flag.String("ssl-cert", "", "Ssl cert for websocket (optional)")
 	sslKey   = flag.String("ssl-key", "", "Ssl key for websocket (optional)")
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool { return true },


### PR DESCRIPTION
Adds args for --ssl-cert and --ssl-key. If both are specified, this will use `ListenAndServeTLS` instead of `ListenAndServe`. Tested and works, when combined with Lightspeed-react using wss:// in config.json as well as the same ssl cert and ssl key.